### PR TITLE
Bump to node-ipc-promise 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tdl-multiprocess",
   "version": "0.0.2",
   "dependencies": {
-    "node-ipc-promise": "0.1.1"
+    "node-ipc-promise": "0.1.2"
   },
   "peerDependencies": {
     "tdl": "^5.2.0"


### PR DESCRIPTION
This is to address https://github.com/aihornmac/node-ipc-promise/issues/5 because of which tdl-multiprocess is also practically unusable.