### PR TITLE
Fix getName callback response unneeded deserialization

### DIFF
--- a/lib/Child.js
+++ b/lib/Child.js
@@ -70,12 +70,7 @@ class Child extends EventEmitter {
       }
 
       if (loginDetails.getName) {
-        details.getName = () => {
-          return ipc.exec('getName')
-            .then(result => {
-              return JSON.parse(result)
-            })
-        }
+        details.getName = () => ipc.exec('getName')
       } else {
         delete details.getName
       }


### PR DESCRIPTION
The current proxied getName callback is broken. The data returned by user-provided callback is passed to IPC as is:

https://github.com/Jollor/tdl-multiprocess/blob/01fde126b4f877bafba821c3a04fa6d5dea90d75/lib/Client.js#L68
https://github.com/Jollor/tdl-multiprocess/blob/01fde126b4f877bafba821c3a04fa6d5dea90d75/lib/Client.js#L39-L41

but then the child tries to parse it as JSON (and crashes):

https://github.com/Jollor/tdl-multiprocess/blob/01fde126b4f877bafba821c3a04fa6d5dea90d75/lib/Child.js#L73-L78

The account registration is therefore broken with tdl-mutltiprocess.

The PR removes the unneeded deserialization (honestly, I'm not sure why do you want to serialize other request/responses..`node-ipc-promise` seems to be doing that already just fine.)